### PR TITLE
Updates signing set-up

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,13 @@ jobs:
         with:
           java-version: 8
 
+      - name: Set-up signing
+        run: ./release/signing.sh
+        env:
+          GPG_KEY_CONTENTS: ${{ secrets.GPG_KEY_CONTENTS }}
+          ORG_GRADLE_PROJECT_SIGNINGKEYID: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+          ORG_GRADLE_PROJECT_SIGNINGPASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+
       - name: Generate cache key
         run: ./checksum.sh checksum.txt
 
@@ -55,15 +62,16 @@ jobs:
         env:
           SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          ORG_GRADLE_PROJECT_SIGNINGKEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
-          ORG_GRADLE_PROJECT_SIGNINGKEYID: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-          ORG_GRADLE_PROJECT_SIGNINGPASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
 
       - name: Create release for tags
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean secrets
+        if: always()
+        run: ./release/clean-secrets.sh
 
       - name: Upload build reports
         if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,8 @@ plugins {
     id("com.diffplug.gradle.spotless") version Versions.spotless
     id("io.gitlab.arturbosch.detekt") version Versions.detekt
 
-    id("com.vanniktech.android.junit.jacoco") version "0.16.0"
+    id("com.vanniktech.android.junit.jacoco") version Versions.junitJacoco
+    id("com.vanniktech.maven.publish") version Versions.mavenPublish
 }
 
 repositories {

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -9,6 +9,8 @@ object Versions {
     const val spotless = "3.30.0"
     const val detekt = "1.10.0"
     const val jacoco = "0.8.5"
+    const val junitJacoco = "0.16.0"
+    const val mavenPublish = "0.12.0"
 }
 
 object Libs {

--- a/interactor/build.gradle.kts
+++ b/interactor/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("kotlin")
     kotlin("kapt")
-    id("maven-publish")
+    id("com.vanniktech.maven.publish")
 }
 
 dependencies {

--- a/logging-api/build.gradle.kts
+++ b/logging-api/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("kotlin")
     kotlin("kapt")
-    id("maven-publish")
+    id("com.vanniktech.maven.publish")
 }
 
 dependencies {

--- a/release/clean-secrets.sh
+++ b/release/clean-secrets.sh
@@ -1,0 +1,5 @@
+GPG_LOCATION=~/.gradle/release.gpg
+GRADLE_PROPERTIES_LOCATION=~/.gradle/gradle.properties
+
+rm $GPG_LOCATION
+rm $GRADLE_PROPERTIES_LOCATION

--- a/release/signing.sh
+++ b/release/signing.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+create_gradle_properties() {
+  KEYID=$1
+  PASSWORD=$2
+  GPG_KEY_CONTENTS=$3
+  GPG_LOCATION=~/.gradle/release.gpg
+  GRADLE_PROPERTIES_LOCATION=~/.gradle/gradle.properties
+
+  rm -f $GPG_LOCATION
+  rm -f $GRADLE_PROPERTIES_LOCATION
+
+  echo $GPG_KEY_CONTENTS | base64 -d > $GPG_LOCATION
+
+  printf "signing.keyId=$KEYID\nsigning.password=$PASSWORD\nsigning.secretKeyRingFile=$GPG_LOCATION\n" >> $GRADLE_PROPERTIES_LOCATION
+}
+
+create_gradle_properties $ORG_GRADLE_PROJECT_signingKeyId $ORG_GRADLE_PROJECT_signingPassword $GPG_KEY_CONTENTS

--- a/release/signing.sh
+++ b/release/signing.sh
@@ -7,11 +7,10 @@ create_gradle_properties() {
   GPG_LOCATION=~/.gradle/release.gpg
   GRADLE_PROPERTIES_LOCATION=~/.gradle/gradle.properties
 
+  mkdir -p ~/.gradle
+
   rm -f $GPG_LOCATION
   rm -f $GRADLE_PROPERTIES_LOCATION
-
-  touch $GPG_LOCATION
-  touch $GRADLE_PROPERTIES_LOCATION
 
   echo $GPG_KEY_CONTENTS | base64 -d > $GPG_LOCATION
 

--- a/release/signing.sh
+++ b/release/signing.sh
@@ -10,6 +10,9 @@ create_gradle_properties() {
   rm -f $GPG_LOCATION
   rm -f $GRADLE_PROPERTIES_LOCATION
 
+  touch $GPG_LOCATION
+  touch $GRADLE_PROPERTIES_LOCATION
+
   echo $GPG_KEY_CONTENTS | base64 -d > $GPG_LOCATION
 
   printf "signing.keyId=$KEYID\nsigning.password=$PASSWORD\nsigning.secretKeyRingFile=$GPG_LOCATION\n" >> $GRADLE_PROPERTIES_LOCATION


### PR DESCRIPTION
Updates signing set-up to create a `gradle.properties` in the home folder along with a `release.gpg`. These can then be used by the signing plugin.